### PR TITLE
fix container height

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -243,7 +243,7 @@ export default class Carousel extends Component {
             width={width}
             height={height}
             contentContainerStyle={[
-              styles.contentContainer,
+              {height},
               contentContainerStyle,
             ]}
             onScroll={onScroll}

--- a/src/styles/carousel.js
+++ b/src/styles/carousel.js
@@ -5,9 +5,6 @@
 import {StyleSheet} from 'react-native';
 
 export default StyleSheet.create({
-  contentContainer: {
-    height: 200,
-  },
   pageIndicator: {
     position: 'absolute',
     flexDirection: 'row',


### PR DESCRIPTION
In iOS, passing `height` props less than 200 as to Carousel component, then it allows the contents of the carousel to move within the height of 200.
Even so, there is no reasonable reason to fix the height at 200.