### PR TITLE
Fix react-native version 0.60+ issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "react-mixin": "^3.0.5",
-    "react-timer-mixin": "^0.13.3"
+    "react-timer-mixin": "^0.13.3",
+    "@react-native-community/viewpager": "^2.0.1"
   }
 }

--- a/src/carouselPager.android.js
+++ b/src/carouselPager.android.js
@@ -2,9 +2,7 @@
  * @flow
  */
 import React, {Component} from 'react';
-import {
-  ViewPagerAndroid,
-} from 'react-native';
+import ViewPagerAndroid from '@react-native-community/viewpager'
 
 type Props = {
   width: number,


### PR DESCRIPTION
From v0.60 on ard `ViewPagerAndroid` is not anymore part of react-native, and it has been moved to [separate repository](https://github.com/react-native-community/react-native-viewpager), and it's now maintained by react-native-community.